### PR TITLE
Feature parse datetime

### DIFF
--- a/nova_api/entity.py
+++ b/nova_api/entity.py
@@ -44,6 +44,19 @@ class Entity:
                     self.__setattr__(field_.name, field_.type(
                         self.__getattribute__(field_.name)
                     ))
+                if (issubclass(field_.type, datetime) \
+                    or issubclass(field_.type, date)) \
+                        and \
+                        not isinstance(self.__getattribute__(field_.name),
+                                       field_.type):
+                    logger.debug("Received %s field as %s. Converting.",
+                                 type(self.__getattribute__(field_.name)),
+                                 field_.type)
+                    self.__setattr__(field_.name, 
+                                     datetime.strptime(
+                        self.__getattribute__(field_.name),
+                        field.metadata.get("datetime_format", "%Y-%m-%d %H:%M%S")
+                    ))  
             except TypeError:
                 logger.warning("Unable to check field %s type",
                                field_.name, exc_info=True)

--- a/nova_api/entity.py
+++ b/nova_api/entity.py
@@ -51,11 +51,14 @@ class Entity:
                     logger.debug("Received %s field as %s. Converting.",
                                  type(self.__getattribute__(field_.name)),
                                  field_.type)
-                    self.__setattr__(field_.name, 
-                                     datetime.strptime(
-                        self.__getattribute__(field_.name),
-                        field_.metadata.get("datetime_format", "%Y-%m-%d %H:%M%S")
-                    ))
+                    self.__setattr__(
+                        field_.name,
+                        datetime.strptime(
+                            self.__getattribute__(field_.name),
+                            field_.metadata.get("datetime_format",
+                                                "%Y-%m-%d "
+                                                "%H:%M:%S")
+                        ))
                 if issubclass(field_.type, date) \
                         and \
                         not isinstance(self.__getattribute__(field_.name),
@@ -63,11 +66,13 @@ class Entity:
                     logger.debug("Received %s field as %s. Converting.",
                                  type(self.__getattribute__(field_.name)),
                                  field_.type)
-                    self.__setattr__(field_.name, 
-                                     datetime.strptime(
-                        self.__getattribute__(field_.name),
-                        field_.metadata.get("date_format", "%Y-%m-%d")
-                    ).date())   
+                    self.__setattr__(
+                        field_.name,
+                        datetime.strptime(
+                            self.__getattribute__(field_.name),
+                            field_.metadata.get("date_format",
+                                                "%Y-%m-%d")
+                        ).date())
             except TypeError:
                 logger.warning("Unable to check field %s type",
                                field_.name, exc_info=True)

--- a/nova_api/entity.py
+++ b/nova_api/entity.py
@@ -44,8 +44,7 @@ class Entity:
                     self.__setattr__(field_.name, field_.type(
                         self.__getattribute__(field_.name)
                     ))
-                if (issubclass(field_.type, datetime) \
-                    or issubclass(field_.type, date)) \
+                if issubclass(field_.type, datetime) \
                         and \
                         not isinstance(self.__getattribute__(field_.name),
                                        field_.type):
@@ -55,8 +54,20 @@ class Entity:
                     self.__setattr__(field_.name, 
                                      datetime.strptime(
                         self.__getattribute__(field_.name),
-                        field.metadata.get("datetime_format", "%Y-%m-%d %H:%M%S")
-                    ))  
+                        field_.metadata.get("datetime_format", "%Y-%m-%d %H:%M%S")
+                    ))
+                if issubclass(field_.type, date) \
+                        and \
+                        not isinstance(self.__getattribute__(field_.name),
+                                       field_.type):
+                    logger.debug("Received %s field as %s. Converting.",
+                                 type(self.__getattribute__(field_.name)),
+                                 field_.type)
+                    self.__setattr__(field_.name, 
+                                     datetime.strptime(
+                        self.__getattribute__(field_.name),
+                        field_.metadata.get("date_format", "%Y-%m-%d")
+                    ).date())   
             except TypeError:
                 logger.warning("Unable to check field %s type",
                                field_.name, exc_info=True)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="NovaAPI",
-    version="0.1.1",
+    version="0.2.0a1",
     license='MIT',
     author="Mateus Berardo & Fábio Trevizolo",
     author_email="mateust@novaweb.mobi, fabiots@novaweb.mobi",

--- a/tests/unittests/test_entity.py
+++ b/tests/unittests/test_entity.py
@@ -5,6 +5,8 @@ from typing import List
 from pytest import fixture, raises
 
 from nova_api.entity import Entity
+
+
 # pylint: disable=R0201
 @dataclass
 class SampleEntity(Entity):
@@ -16,6 +18,22 @@ class EntityForTest(Entity):
     test_field: int = 0
     my_date: date = field(default=date(2020, 1, 1))
     child: SampleEntity = None
+
+
+@dataclass
+class EntityForTestWithDateFormat(Entity):
+    my_date: date = field(default=None, metadata={
+        "date_format": "%d/%m/%Y",
+    })
+    my_datetime: datetime = field(default=None, metadata={
+        "datetime_format": "%d/%m/%Y %H:%M",
+    })
+
+
+@dataclass
+class EntityForTestWithDatetime(Entity):
+    my_date: datetime = field(default=datetime(year=2020, month=1, day=12))
+
 
 @dataclass
 class EntityForTestWithTypeError(Entity):
@@ -30,14 +48,14 @@ class TestEntity:
                              datetime(2020, 1, 1, 0, 0, 0),
                              datetime(2020, 1, 1, 0, 0, 0),
                              0, child=SampleEntity(
-                                 "12345678901234567890123456789012"))
+                "12345678901234567890123456789012"))
 
     def test_auto_generate_id(self, entity):
         assert len(entity.id_) == 32
 
     def test_datetime_generation(self, entity):
         assert isinstance(entity.creation_datetime, datetime) \
-                and isinstance(entity.last_modified_datetime, datetime)
+               and isinstance(entity.last_modified_datetime, datetime)
 
     def test_to_dict(self, entity):
         entity_dict = dict(entity)
@@ -55,3 +73,26 @@ class TestEntity:
     def test_field_type_error(self):
         ent = EntityForTestWithTypeError()
         assert isinstance(ent, EntityForTestWithTypeError)
+
+    def test_date_parsing(self):
+        ent1 = EntityForTest(my_date="2020-1-1")
+        ent2 = EntityForTest(id_=ent1.id_)
+        assert ent1 == ent2
+
+    def test_datetime_parsing(self):
+        ent1 = EntityForTestWithDatetime(my_date="2020-1-12 00:00:00")
+        ent2 = EntityForTestWithDatetime(id_=ent1.id_)
+        assert ent1 == ent2
+
+    def test_format_date(self):
+        ent1 = EntityForTestWithDateFormat(my_date="13/8/2020",
+                                           my_datetime="14/09/2021 19:07")
+        ent2 = EntityForTestWithDateFormat(id_=ent1.id_,
+                                           my_date=date(day=13,
+                                                        month=8, year=2020),
+                                           my_datetime=datetime(day=14,
+                                                                month=9,
+                                                                year=2021,
+                                                                hour=19,
+                                                                minute=7))
+        assert ent1 == ent2


### PR DESCRIPTION
Add support for parsing of string arguments in constructor for date/datetime fields. Add format string as (optional) metadata ("date_format" and "datetime_format").

**Test plan (required)**

 - Compare two entities, one instantiated with date and datetime fields as string and one with a datetime.
 - Try different string formats informed at metadata

**Code formatting**

Follows PEP8

**Closing issues**
closes #27 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] I have read the **CONTRIBUTING** document.
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [X] All new and existing tests passed.

