### PR TITLE
Extra args to database connection on MySQL

### DIFF
--- a/nova_api/__init__.py
+++ b/nova_api/__init__.py
@@ -104,7 +104,7 @@ def success_response(status_code: int = 200, message: str = "OK",
 
 
 def use_dao(dao_class: generic_dao.GenericSQLDAO, error_message: str = "Erro",
-            database_args=None, pooled: bool = False):
+            dao_parameters: dict=None):
     """Decorator to handle database access in an API call
 
     This decorator instantiates the DAO specified in `dao_class` within a try \
@@ -116,14 +116,15 @@ def use_dao(dao_class: generic_dao.GenericSQLDAO, error_message: str = "Erro",
     :param dao_class: DAO to instantiate and pass to the decorated function
     :param error_message: Default error message to send in the error_response \
     if an exception is thrown
-    :param pooled: Enables MySQL connection pooling on DAO class
-    :param database_args: Extra database args to pass to DAO class
+    :param dao_parameters: Parameters to add to the call to the DAO \
+    constructor. They'll be added to the call with the expansion \
+    `**dao_parameters`.
 
     :return: The decorated function
     """
 
-    if database_args is None:
-        database_args = dict()
+    if dao_parameters is None:
+        dao_parameters = dict()
 
     def make_call(function):
 
@@ -139,7 +140,7 @@ def use_dao(dao_class: generic_dao.GenericSQLDAO, error_message: str = "Erro",
                     args,
                     kwargs
                 )
-                dao = dao_class(pooled=pooled, database_args=database_args)
+                dao = dao_class(**dao_parameters)
                 return function(dao=dao, *args, **kwargs)
             # pylint: disable=W0703
             except Exception as exception:

--- a/nova_api/__init__.py
+++ b/nova_api/__init__.py
@@ -103,7 +103,8 @@ def success_response(status_code: int = 200, message: str = "OK",
                             message=message, data=data)
 
 
-def use_dao(dao_class: generic_dao.GenericSQLDAO, error_message: str = "Erro"):
+def use_dao(dao_class: generic_dao.GenericSQLDAO, error_message: str = "Erro",
+            database_args=None, pooled: bool = False):
     """Decorator to handle database access in an API call
 
     This decorator instantiates the DAO specified in `dao_class` within a try \
@@ -115,9 +116,14 @@ def use_dao(dao_class: generic_dao.GenericSQLDAO, error_message: str = "Erro"):
     :param dao_class: DAO to instantiate and pass to the decorated function
     :param error_message: Default error message to send in the error_response \
     if an exception is thrown
+    :param pooled: Enables MySQL connection pooling on DAO class
+    :param database_args: Extra database args to pass to DAO class
 
     :return: The decorated function
     """
+
+    if database_args is None:
+        database_args = dict()
 
     def make_call(function):
 
@@ -133,7 +139,7 @@ def use_dao(dao_class: generic_dao.GenericSQLDAO, error_message: str = "Erro"):
                     args,
                     kwargs
                 )
-                dao = dao_class()
+                dao = dao_class(pooled=pooled, database_args=database_args)
                 return function(dao=dao, *args, **kwargs)
             # pylint: disable=W0703
             except Exception as exception:

--- a/nova_api/generic_dao.py
+++ b/nova_api/generic_dao.py
@@ -34,7 +34,8 @@ class GenericSQLDAO:
     # pylint: disable=R0913
     def __init__(self, database=None, table: str = None, fields: dict = None,
                  return_class: dataclasses.dataclass = Entity,
-                 prefix: str = None, pooled: bool = True) -> None:
+                 prefix: str = None, pooled: bool = True,
+                 database_args: dict = None) -> None:
 
         self.logger = logging.getLogger(__name__)
 
@@ -43,9 +44,17 @@ class GenericSQLDAO:
                           self.__class__.__name__, database, table, fields,
                           return_class, prefix)
 
+        if database_args is None:
+            database_args = dict()
+
+
         self.database = database
         if database is None:
-            self.database = MySQLHelper(pooled=pooled)
+            self.logger.info("Database connection starting. Pooled: %s. "
+                             "Extras: %s.", pooled, database_args)
+            self.database = MySQLHelper(pooled=pooled,
+                                        database_args=database_args)
+            self.logger.info("Connected to database.")
 
         self.return_class = return_class
 

--- a/nova_api/generic_dao.py
+++ b/nova_api/generic_dao.py
@@ -34,8 +34,7 @@ class GenericSQLDAO:
     # pylint: disable=R0913
     def __init__(self, database=None, table: str = None, fields: dict = None,
                  return_class: dataclasses.dataclass = Entity,
-                 prefix: str = None, pooled: bool = True,
-                 database_args: dict = None, **kwargs) -> None:
+                 prefix: str = None, **kwargs) -> None:
 
         self.logger = logging.getLogger(__name__)
 
@@ -44,16 +43,11 @@ class GenericSQLDAO:
                           self.__class__.__name__, database, table, fields,
                           return_class, prefix)
 
-        if database_args is None:
-            database_args = dict()
-
         self.database = database
         if database is None:
-            self.logger.info("Database connection starting. Pooled: %s. "
-                             "Extras: %s.", pooled, database_args)
-            self.database = MySQLHelper(pooled=pooled,
-                                        database_args=database_args,
-                                        **kwargs)
+            self.logger.info("Database connection starting. Extra args: %s. ",
+                             kwargs)
+            self.database = MySQLHelper(**kwargs)
             self.logger.info("Connected to database.")
 
         self.return_class = return_class

--- a/nova_api/generic_dao.py
+++ b/nova_api/generic_dao.py
@@ -35,7 +35,7 @@ class GenericSQLDAO:
     def __init__(self, database=None, table: str = None, fields: dict = None,
                  return_class: dataclasses.dataclass = Entity,
                  prefix: str = None, pooled: bool = True,
-                 database_args: dict = None) -> None:
+                 database_args: dict = None, **kwargs) -> None:
 
         self.logger = logging.getLogger(__name__)
 
@@ -47,13 +47,13 @@ class GenericSQLDAO:
         if database_args is None:
             database_args = dict()
 
-
         self.database = database
         if database is None:
             self.logger.info("Database connection starting. Pooled: %s. "
                              "Extras: %s.", pooled, database_args)
             self.database = MySQLHelper(pooled=pooled,
-                                        database_args=database_args)
+                                        database_args=database_args,
+                                        **kwargs)
             self.logger.info("Connected to database.")
 
         self.return_class = return_class

--- a/nova_api/mysql_pool.py
+++ b/nova_api/mysql_pool.py
@@ -19,14 +19,18 @@ class MySQLPool:
                      user: str = os.environ.get('DB_USER'),
                      password: str = os.environ.get('DB_PASSWORD'),
                      database: str = os.environ.get('DB_NAME'),
-                     size: int = os.environ.get('MYSQL_POOL_SIZE', 5)) \
+                     size: int = os.environ.get('MYSQL_POOL_SIZE', 5),
+                     database_args: dict = None) \
             -> pooling.MySQLConnectionPool:
         """
         Get an instance of a database connection pool.
 
         This checks the existence of a connection pool with the specified \
         server and database and return the existent connection or a new one \
-        if it doesn't exists
+        if it doesn't exists. Any database args that should be used have to \
+        be passed at the first call to create a pool. `database_args` are \
+        not verified at every call and are not used to compare the required \
+        and available pools.
 
         :param host: The database URL to connect
         :param user: The database user to use
@@ -34,15 +38,19 @@ class MySQLPool:
         :param database: The database name to use
         :param size: Number of connections to keep in the pool. \
         Defaults to 5.
+        :param database_args: Extra options to pass to database connection.
         :return: The connection pool instance
         """
+        if database_args is None:
+            database_args = dict()
+
         pool_name = user + "_" + host + "-" + database
         instance = cls.instances.get(pool_name, None)
 
         cls.logger.info("Requested connection from pool: %s", pool_name)
 
         if instance:
-            cls.logger.info("Pool already connected: %s", pool_name)
+            cls.logger.info("Pool already connected: %s. ", pool_name)
             return instance
 
         cls.logger.info("Pool not connected, instantiating: %s", pool_name)
@@ -53,7 +61,8 @@ class MySQLPool:
             host=host,
             database=database,
             user=user,
-            password=password)
+            password=password,
+            **database_args)
         cls.instances[pool_name] = instance
 
         cls.logger.info("Pool instantiated: %s", pool_name)

--- a/tests/unittests/test_api_utils.py
+++ b/tests/unittests/test_api_utils.py
@@ -70,7 +70,33 @@ class TestAPIUtils:
             return kwargs.get('dao') == my_mock.return_value
 
         ret = test()
-        assert my_mock.mock_calls == [call(), call().close()] and ret
+        assert my_mock.mock_calls == [call(database_args={},
+                                           pooled=False),
+                                      call().close()] and ret
+
+    def test_use_dao_db_args(self, mocker):
+        my_mock = Mock()
+
+        @nova_api.use_dao(dao_class=my_mock, database_args={"ssl_ca": "file"})
+        def test(**kwargs):
+            return kwargs.get('dao') == my_mock.return_value
+
+        ret = test()
+        assert my_mock.mock_calls == [call(database_args={"ssl_ca": "file"},
+                                           pooled=False),
+                                      call().close()] and ret
+
+    def test_use_dao_pooled(self, mocker):
+        my_mock = Mock()
+
+        @nova_api.use_dao(dao_class=my_mock, pooled=True)
+        def test(**kwargs):
+            return kwargs.get('dao') == my_mock.return_value
+
+        ret = test()
+        assert my_mock.mock_calls == [call(database_args={},
+                                           pooled=True),
+                                      call().close()] and ret
 
     def test_use_dao_exception(self, mocker):
         my_mock = Mock()
@@ -83,7 +109,8 @@ class TestAPIUtils:
                 raise Exception()
 
         ret = test()
-        assert my_mock.mock_calls == [call(), call().close()]
+        assert my_mock.mock_calls == [call(database_args={},
+                                           pooled=False), call().close()]
         assert ret == "NOT OK"
 
     def test_generate_valid_api_yml(self):

--- a/tests/unittests/test_generic_sql_dao.py
+++ b/tests/unittests/test_generic_sql_dao.py
@@ -138,6 +138,27 @@ class TestGenericSQLDAO:
                                       "birthday": "birthday"}
         assert generic_dao.return_class == TestEntity
 
+    def test_init_extra_params(self, mysql_mock):
+        generic_dao = GenericSQLDAO(
+            fields={"id_": "id",
+                    "creation_datetime": "creation_datetime",
+                    "last_modified_datetime": "last_modified_datetime",
+                    "name": "name",
+                    "birthday": "birthday"},
+            return_class=TestEntity,
+            pooled=False, host="changed")
+        assert mysql_mock.mock_calls == [call(host="changed", pooled=False,
+                                              database_args={})]
+        assert generic_dao.database == mysql_mock.return_value
+        assert generic_dao.table == "test_entitys"
+        assert generic_dao.fields == {"id_": "id",
+                                      "creation_datetime": "creation_datetime",
+                                      "last_modified_datetime":
+                                          "last_modified_datetime",
+                                      "name": "name",
+                                      "birthday": "birthday"}
+        assert generic_dao.return_class == TestEntity
+
     def test_init_pooled(self, mysql_mock):
         generic_dao = GenericSQLDAO(
             fields={"id_": "id",

--- a/tests/unittests/test_generic_sql_dao.py
+++ b/tests/unittests/test_generic_sql_dao.py
@@ -125,9 +125,8 @@ class TestGenericSQLDAO:
                     "last_modified_datetime": "last_modified_datetime",
                     "name": "name",
                     "birthday": "birthday"},
-            return_class=TestEntity,
-            pooled=False)
-        assert mysql_mock.mock_calls == [call(pooled=False, database_args={})]
+            return_class=TestEntity)
+        assert mysql_mock.mock_calls == [call()]
         assert generic_dao.database == mysql_mock.return_value
         assert generic_dao.table == "test_entitys"
         assert generic_dao.fields == {"id_": "id",
@@ -147,8 +146,7 @@ class TestGenericSQLDAO:
                     "birthday": "birthday"},
             return_class=TestEntity,
             pooled=False, host="changed")
-        assert mysql_mock.mock_calls == [call(host="changed", pooled=False,
-                                              database_args={})]
+        assert mysql_mock.mock_calls == [call(host="changed", pooled=False)]
         assert generic_dao.database == mysql_mock.return_value
         assert generic_dao.table == "test_entitys"
         assert generic_dao.fields == {"id_": "id",
@@ -167,7 +165,7 @@ class TestGenericSQLDAO:
                     "name": "name",
                     "birthday": "birthday"},
             return_class=TestEntity, pooled=True)
-        assert mysql_mock.mock_calls == [call(pooled=True, database_args={})]
+        assert mysql_mock.mock_calls == [call(pooled=True)]
         assert generic_dao.database == mysql_mock.return_value
         assert generic_dao.table == "test_entitys"
         assert generic_dao.fields == {"id_": "id",

--- a/tests/unittests/test_generic_sql_dao.py
+++ b/tests/unittests/test_generic_sql_dao.py
@@ -127,7 +127,7 @@ class TestGenericSQLDAO:
                     "birthday": "birthday"},
             return_class=TestEntity,
             pooled=False)
-        assert mysql_mock.mock_calls == [call(pooled=False)]
+        assert mysql_mock.mock_calls == [call(pooled=False, database_args={})]
         assert generic_dao.database == mysql_mock.return_value
         assert generic_dao.table == "test_entitys"
         assert generic_dao.fields == {"id_": "id",
@@ -146,7 +146,27 @@ class TestGenericSQLDAO:
                     "name": "name",
                     "birthday": "birthday"},
             return_class=TestEntity, pooled=True)
-        assert mysql_mock.mock_calls == [call(pooled=True)]
+        assert mysql_mock.mock_calls == [call(pooled=True, database_args={})]
+        assert generic_dao.database == mysql_mock.return_value
+        assert generic_dao.table == "test_entitys"
+        assert generic_dao.fields == {"id_": "id",
+                                      "creation_datetime": "creation_datetime",
+                                      "last_modified_datetime":
+                                          "last_modified_datetime",
+                                      "name": "name",
+                                      "birthday": "birthday"}
+        assert generic_dao.return_class == TestEntity
+
+    def test_init_pooled_database_args(self, mysql_mock):
+        generic_dao = GenericSQLDAO(
+            fields={"id_": "id",
+                    "creation_datetime": "creation_datetime",
+                    "last_modified_datetime": "last_modified_datetime",
+                    "name": "name",
+                    "birthday": "birthday"},
+            return_class=TestEntity, pooled=True,
+            database_args={"ssl_ca": "file"})
+        assert mysql_mock.mock_calls == [call(pooled=True, database_args={"ssl_ca": "file"})]
         assert generic_dao.database == mysql_mock.return_value
         assert generic_dao.table == "test_entitys"
         assert generic_dao.fields == {"id_": "id",

--- a/tests/unittests/test_mysqlpoll.py
+++ b/tests/unittests/test_mysqlpoll.py
@@ -22,6 +22,26 @@ class TestMySQLPoll:
             user='test_user',
             password='test_passwd')]
 
+    def test_get_instance_exist_extra_args(self, pooling_mock):
+        MySQLPool.get_instance(host="test_host", user="test_user",
+                               password="test_passwd", database="test_db",
+                               database_args={"ssl_ca": "file"})
+        assert pooling_mock.mock_calls == []
+
+    def test_get_instance_not_exist_extra_args(self, pooling_mock):
+        MySQLPool.get_instance(host="test_host2", user="test_user",
+                               password="test_passwd", database="test_db",
+                               database_args={"ssl_ca": "file"})
+        assert pooling_mock.mock_calls == [call.MySQLConnectionPool(
+            pool_name='test_user_test_host2-test_db',
+            pool_size=5,
+            pool_reset_session=True,
+            host='test_host2',
+            database='test_db',
+            user='test_user',
+            password='test_passwd',
+            ssl_ca='file')]
+
     def test_get_instance_exist(self, pooling_mock):
         inst_1 = MySQLPool.get_instance(host="test_host", user="test_user",
                                         password="test_passwd",
@@ -41,3 +61,5 @@ class TestMySQLPoll:
                                         database="test_db2")
         assert inst_1 is not None and inst_2 is not None
         assert inst_1 != inst_2
+
+


### PR DESCRIPTION
Explain the **details** for making this change. What existing problem does the pull request solve?

The connection to the database only included basic arguments (host, user, password, database). Other arguments may be needed, as *port* and *ssl_ca*. This should be added in all levels, including the use_dao decorator to guarantee the possibility of personalizing the usage of such arguments without the need to change the DAO class code.

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Test plan (required)**

 - Added tests to MySQLPool to check the usage of database args on connect (There is no check if the available instance has this args set and this is the expected behavior, which is being tested)
 -  Added tests to MySQLHelper to check the usage
 - Added tests to GenericSQLDAO to check the usage
 - Added tests to use_dao to check usage of database_args

<!-- Make sure tests pass! -->

**Code formatting**
OK

**Closing issues**

closes #40

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] I have read the **CONTRIBUTING** document.
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

