### PR TITLE
Added retries if dao instantiation failed

### DIFF
--- a/nova_api/__init__.py
+++ b/nova_api/__init__.py
@@ -3,6 +3,7 @@ import getopt
 import logging
 import os
 import sys
+import time
 from dataclasses import fields
 from functools import wraps
 
@@ -103,8 +104,12 @@ def success_response(status_code: int = 200, message: str = "OK",
                             message=message, data=data)
 
 
-def use_dao(dao_class: generic_dao.GenericSQLDAO, error_message: str = "Erro",
-            dao_parameters: dict=None):
+def use_dao(dao_class: generic_dao.GenericSQLDAO,
+            error_message: str = "Erro",
+            dao_parameters: dict = None,
+            retry_delay: int = int(os.environ.get("NOVAAPI_RETRY_DELAY",
+                                                  "1")),
+            retries: float = float(os.environ.get("NOVAAPI_RETRIES", "3")),):
     """Decorator to handle database access in an API call
 
     This decorator instantiates the DAO specified in `dao_class` within a try \
@@ -119,6 +124,11 @@ def use_dao(dao_class: generic_dao.GenericSQLDAO, error_message: str = "Erro",
     :param dao_parameters: Parameters to add to the call to the DAO \
     constructor. They'll be added to the call with the expansion \
     `**dao_parameters`.
+    :param retries: Number of times to retry connection with database. \
+    Defaults to 3. May be set through the env variable NOVAAPI_RETRIES
+    :param retry_delay: Seconds to wait before retrying to connect to \
+    database. Defaults to 1.0. May be set through the env variable \
+    NOVAAPI_RETRY_DELAY.
 
     :return: The decorated function
     """
@@ -140,7 +150,21 @@ def use_dao(dao_class: generic_dao.GenericSQLDAO, error_message: str = "Erro",
                     args,
                     kwargs
                 )
-                dao = dao_class(**dao_parameters)
+
+                attempted_retries = retries
+                while attempted_retries:
+                    try:
+                        dao = dao_class(**dao_parameters)
+                        break
+                    except ConnectionError as con_error:
+                        print("Connection failed, will retry "
+                                       "%s times"% attempted_retries)
+                        time.sleep(retry_delay)
+                        if attempted_retries == 1:
+                            raise con_error
+                    finally:
+                        attempted_retries -= 1
+
                 return function(dao=dao, *args, **kwargs)
             # pylint: disable=W0703
             except Exception as exception:

--- a/nova_api/__init__.py
+++ b/nova_api/__init__.py
@@ -107,9 +107,9 @@ def success_response(status_code: int = 200, message: str = "OK",
 def use_dao(dao_class: generic_dao.GenericSQLDAO,
             error_message: str = "Erro",
             dao_parameters: dict = None,
-            retry_delay: int = int(os.environ.get("NOVAAPI_RETRY_DELAY",
-                                                  "1")),
-            retries: float = float(os.environ.get("NOVAAPI_RETRIES", "3")),):
+            retry_delay: float = float(os.environ.get("NOVAAPI_RETRY_DELAY",
+                                                  "1.0")),
+            retries: int = int(os.environ.get("NOVAAPI_RETRIES", "3")),):
     """Decorator to handle database access in an API call
 
     This decorator instantiates the DAO specified in `dao_class` within a try \


### PR DESCRIPTION
Explain the **details** for making this change. What existing problem does the pull request solve?

When the attempt to connect to the database fails the request responds with 500. The failure may be caused by a transient problem, so there may be gains by retrying the connection. This adds retries to the use_dao decorator. The retries only apply to the dao connection.

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Test plan (required)**

Added test of use_dao with retries set -> expect an equivalent number of calls to retry and a duration of the call at least of n*retry_delay.

<!-- Make sure tests pass! -->

**Code formatting**

Ok

**Closing issues**

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] I have read the **CONTRIBUTING** document.
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

